### PR TITLE
Fixes Bump Version Break in Main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "edunet"
-version = "0.2.2"
+version = "0.2.3"
 description = "Simple Network Simulation For The Funs!"
 authors = ["Wajdi Al-Hawari <w.hawari@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
The dependabot MR does not set the version bump as it is done manually. An issue will need to be opened to address this by performing an auto patch bump for dependabot MRs.